### PR TITLE
pcsx2: Persist textures directory

### DIFF
--- a/bucket/pcsx2.json
+++ b/bucket/pcsx2.json
@@ -43,7 +43,8 @@
         "memcards",
         "shaders\\GSdx_FX_Settings.ini",
         "snaps",
-        "sstates"
+        "sstates",
+        "textures"
     ],
     "checkver": {
         "github": "https://github.com/PCSX2/pcsx2/"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Persist the `textures` directory so they remain usable across different versions. The `pcsx2-dev` package already has this, but for some reason it's missing from the stable version.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
