### PR TITLE
xn-connect: add version 1.0.9

### DIFF
--- a/bucket/xn-connect.json
+++ b/bucket/xn-connect.json
@@ -1,0 +1,16 @@
+{
+    "version": "1.0.9",
+    "description": "CLI client for XN Connect - tunnel your game servers to the internet",
+    "homepage": "https://connect.xneon.org",
+    "license": "Proprietary",
+    "url": "https://connect.xneon.org/downloads/1.0.9/xn-connect-windows-amd64.exe",
+    "hash": "91526f261fa10ff9369de70a6786773d7780a6357d87d22d47c3deee7dcb9f799",
+    "bin": "xn-connect.exe",
+    "checkver": {
+        "url": "https://connect.xneon.org/api/cli/version",
+        "jsonpath": "$.version"
+    },
+    "autoupdate": {
+        "url": "https://connect.xneon.org/downloads/$version/xn-connect-windows-amd64.exe"
+    }
+}


### PR DESCRIPTION
Add xn-connect to scoop-games. XN Connect is a CLI client for tunneling local game servers (Minecraft, Terraria, Rust, CS2, etc.) to the internet via relay nodes. checkver and autoupdate are configured.